### PR TITLE
Fixes grammatical error in readme to restart API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BaniDB API
-Active work ongoing under dev branch
+Active work ongoing under the dev branch
 
 # Vision Statement
 BaniDB's vision is to create a single, universally accessible Gurbani Database for websites and applications. BaniDB is and will continue to be the most accurate and complete Gurbani database ever created.


### PR DESCRIPTION
The actual reason for this fix is to force a restart of the API, to temporaily fix the following error 
`{"error":true,"data":{"fatal":false,"errno":45028,"sqlState":"HY000","code":"ER_GET_CONNECTION_TIMEOUT"}}`