### PR TITLE
Add local db running in docker-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,47 @@
 # BaniDB API
 
-Active work ongoing under dev branch
-=======
+# Active work ongoing under dev branch
+
 [<img height="100" src="http://www.banidb.com/wp-content/uploads/2018/03/full-banidb-logo.png">](http://banidb.com)
 
-[![Email](https://img.shields.io/badge/Email-bod%40khalisfoundation.org-green.svg)](mailto:bod@khalisfoundation.org) 
+[![Email](https://img.shields.io/badge/Email-bod%40khalisfoundation.org-green.svg)](mailto:bod@khalisfoundation.org)
 [![Slack](https://img.shields.io/badge/Slack-join%20the%20conversation-red.svg)](https://khalis.slack.com)
 
 [![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/BJKALklMKao/0.jpg)](https://www.youtube.com/watch?v=BJKALklMKao)
+
+## Contributing
+
+### Prerequisites
+
+1.  [Node](https://nodejs.org/en/download/) (10+)
+    - `nvm` can be used for mac/linux
+2.  [Docker](https://www.docker.com/get-started)
+
+#### Optional
+
+- [MariaDB](https://mariadb.org/download/)
+- [MySQL Workbench](https://dev.mysql.com/downloads/workbench/)
+
+### Installation
+
+- Run `npm ci` in the repository root
+
+### Running
+
+- Run `npm run local` in the repository root
+  - This starts the khalisfoundation/banidb-dev image in a docker container
+- API will run on `http://localhost:3001/v2/`
+
+#### Stopping
+
+- Run `npm run docker:stop` to stop the container
+- Run `npm run docker:clean` to remove the image
+
 # Vision Statement
+
 BaniDB's vision is to create a single, universally accessible Gurbani Database for websites and applications. BaniDB is and will continue to be the most accurate and complete Gurbani database ever created.
 
-In order to make this vision possible, members of this collaborative effort work to ensure that the platform is selfsustaining, tested, and secure. 
+In order to make this vision possible, members of this collaborative effort work to ensure that the platform is selfsustaining, tested, and secure.
 
 # Precision and Recall
 
@@ -19,24 +49,26 @@ BaniDB is the most precise Gurbani database with over 43,000 corrections/changes
 
 It is the only database in the world that is being standardized for lagamatras (spelling) and padh chhedh (word separation) versus the Shiromani Gurdwara Parbandhak Committee's (SGPC) published Gurbani pothis.
 
-Furthermore, no change to the DB is approved without at least 3 peer reviews with full citations and audit trail. This exhaustive process ensures that no individual can tamper with Gurbani.  
+Furthermore, no change to the DB is approved without at least 3 peer reviews with full citations and audit trail. This exhaustive process ensures that no individual can tamper with Gurbani.
 
 We have worked closely with Gursikhs and Sikh scholars around the world to build upon their previous work. These partners and collaborators include SHARE Charity UK, iGurbani, Gursevak, and others. This has allowed us to ensure we have high recall of Gurbani and Panthic sources typically sung in Kirtan or referenced in Katha.
 
 # A Living DB
 
-BaniDB is a collective effort up of a group of dozens of volunteers who ensure that the DB continues to grow, and is properly vetted. 
+BaniDB is a collective effort up of a group of dozens of volunteers who ensure that the DB continues to grow, and is properly vetted.
 
 # Secure
 
 While BaniDB is a collaborative and collective effort, it is imperative that we also ensure it is an effort that secures the sanctity of Gurbani. As a result, we have chosen to take a controlled approach in order to allow for collaboration but also ensure fidelity of Gurbani data. We welcome others to get involved, but have seen too many instances of Gurbani being misused and altered to feel comfortable making the data completely open. This approach is modeled on the approach Sikhs have traditionally taken with Gurbani.
 
 # Get Involved
+
 Interested in coding? Have a love for Gurbani? Want to help with Marketing? Whatever your passions, we would love to work with you. reach out to us and join our active Slack Channel today!
 
 Found a mistake in Gurbani? Have a better translation? Become a contributor to BaniDB! Visit: https://tinyurl.com/banidb-signup for instructions.
 
 # Sources
+
 Below is a list of sources used as ground truth for Gurbani accuracy. We have digitized sources via manual scanning, and have consolidated existing digital sources and uploaded these to www.vidhia.com to help facilitate sudhaee (correction) efforts.
 
 ## Sri Guru Granth Sahib Ji
@@ -343,6 +375,7 @@ Below is a list of sources used as ground truth for Gurbani accuracy. We have di
 </table>
 
 # Feature Comparison
+
 The table below outlines some stats about BaniDB, as of 01/14/2020.
 
 <table cellspacing="0" cellpadding="0" id="banidbapps">
@@ -413,7 +446,7 @@ The table below outlines some stats about BaniDB, as of 01/14/2020.
 
 # Current Users
 
-* [Sundar Gutka - STTM Web](https://www.sikhitothemax.org/sundar-gutka)
+- [Sundar Gutka - STTM Web](https://www.sikhitothemax.org/sundar-gutka)
 
 # Metrics
 
@@ -488,4 +521,3 @@ The table below outlines some stats about BaniDB, as of 01/14/2020.
     <td align="right">7,937</td>
   </tr>
 </table>
-

--- a/bin/clean-up-docker-containers.sh
+++ b/bin/clean-up-docker-containers.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker rmi khalisfoundation/banidb-dev

--- a/bin/docker-compose.yml
+++ b/bin/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.1'
+
+services:
+  database:
+    image: khalisfoundation/banidb-dev
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: khajana_dev_khajana
+    ports:
+      - '3306:3306'

--- a/bin/docker-compose.yml
+++ b/bin/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.1'
 services:
   database:
     image: khalisfoundation/banidb-dev
+    container_name: banidb-api
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: khajana_dev_khajana

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -8,5 +8,5 @@ then
      echo "Starting docker container"
      docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=khajana_dev_khajana -d -p 3306:3306 --name $container_name khalisfoundation/banidb-dev:latest
 else
-      echo "Docker contatiner is running"
+      echo "Docker container is running"
 fi

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=khajana_dev_khajana -d -p 3306:3306 --name banidb-api khalisfoundation/banidb-dev:latest

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -1,2 +1,12 @@
 #!/usr/bin/env bash
-docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=khajana_dev_khajana -d -p 3306:3306 --name banidb-api khalisfoundation/banidb-dev:latest
+
+container_name=banidb-api
+is_running=`docker inspect -f '{{.State.Running}}' $container_name`
+
+if [ -z "$is_running" ]
+then
+     echo "Starting docker container"
+     docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=khajana_dev_khajana -d -p 3306:3306 --name $container_name khalisfoundation/banidb-dev:latest
+else
+      echo "Docker contatiner is running"
+fi

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -3,10 +3,30 @@
 container_name=banidb-api
 is_running=`docker inspect -f '{{.State.Running}}' $container_name`
 
+if [ -z "${DB_PORT}" ]; then 
+    dbPort=3306
+else 
+    dbPort=${DB_PORT}
+fi
+
 if [ -z "$is_running" ]
 then
      echo "Starting docker container"
-     docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=khajana_dev_khajana -d -p 3306:3306 --name $container_name khalisfoundation/banidb-dev:latest
+     docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=khajana_dev_khajana -d -p $dbPort:3306 --name $container_name khalisfoundation/banidb-dev:latest
+     attempt=0
+      while [ $attempt -le 59 ]; do
+      attempt=$(( $attempt + 1 ))
+      echo "Waiting for container to be up (attempt: $attempt)..."
+      result=$(docker exec banidb-api mysqladmin ping -u root -proot 2> /dev/null || echo 'fail' ) 
+      if grep -q 'mysqld is alive' <<< $result ; then
+            echo "DB container is up"
+            echo "Waiting so connections stabalize"
+            break
+      fi
+      sleep 10
+      done
+      sleep 50
+      echo "~~~~Ready~~~~~~"
 else
       echo "Docker container is running"
 fi

--- a/bin/stop-docker.sh
+++ b/bin/stop-docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker kill banidb-api
+docker rm banidb-api

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "dev": "pm2 start process-dev.json",
     "docker:clean": "npm run docker:stop && ./bin/clean-up-docker-containers.sh",
-    "docker:start": "./bin/start-docker.sh",
+    "docker:start": "DB_PORT=3002 ./bin/start-docker.sh",
     "docker:stop": "./bin/stop-docker.sh",
     "e2e-dev": "API_ENV=dev jest --rootDir ./tests/e2e ",
     "e2e": "API_ENV=prod jest --rootDir ./tests/e2e ",
-    "local": "npm run docker:start && NODE_ENV=development node app.js",
+    "local": "DB_PORT=3002 npm run docker:start && DB_PORT=3002 NODE_ENV=development node app.js",
     "postinstall": "npm run test",
     "start": "pm2 start process.json",
     "test": "eslint ."

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "description": "BaniDB API",
   "main": "index.js",
   "scripts": {
-    "start": "pm2 start process.json",
     "dev": "pm2 start process-dev.json",
-    "local": "npm run docker:start && NODE_ENV=development node app.js",
+    "docker:clean": "npm run docker:stop && ./bin/clean-up-docker-containers.sh",
     "docker:start": "./bin/start-docker.sh",
     "docker:stop": "./bin/stop-docker.sh",
-    "docker:clean": "./bin/clean-up-docker-containers.sh",
-    "test": "eslint .",
     "e2e-dev": "API_ENV=dev jest --rootDir ./tests/e2e ",
-    "e2e": "API_ENV=prod jest --rootDir ./tests/e2e "
+    "e2e": "API_ENV=prod jest --rootDir ./tests/e2e ",
+    "local": "npm run docker:start && NODE_ENV=development node app.js",
+    "postinstall": "npm run test",
+    "start": "pm2 start process.json",
+    "test": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "start": "pm2 start process.json",
     "dev": "pm2 start process-dev.json",
+    "local": "npm run docker:start && NODE_ENV=development node app.js",
+    "docker:start": "./bin/start-docker.sh",
+    "docker:stop": "./bin/stop-docker.sh",
+    "docker:clean": "./bin/clean-up-docker-containers.sh",
     "test": "eslint .",
     "e2e-dev": "API_ENV=dev jest --rootDir ./tests/e2e ",
     "e2e": "API_ENV=prod jest --rootDir ./tests/e2e "


### PR DESCRIPTION
I've pushed a image that has the dev db for developers to https://hub.docker.com/repository/docker/khalisfoundation/banidb-dev.

One would 

- Run `npm run local` to start the docker container (in the background) and the app using node (in the foreground)

The app can be stopped normally using `ctrl+c`. 

To stop the docker container run `npm run docker:stop`
