### PR TITLE
#226 Improve Kosh searching results order

### DIFF
--- a/api/controllers/kosh.js
+++ b/api/controllers/kosh.js
@@ -45,9 +45,60 @@ exports.word = async (req, res) => {
   }
 };
 
+exports.wordSearch = async (req, res) => {
+  let conn;
+  const query = `${req.params.query}`;
+  const match = `%${query}%`;
+  const fullMatch = `${query}`;
+  const startMatch = `${query}%`;
+  const endMatch = `%${query}`;
+  try {
+    conn = await req.app.locals.pool.getConnection();
+    const q = `SELECT w.ID AS id, w.Word AS word, w.WordUni AS wordUni,
+                  d.DefGurmukhi AS definition, d.DefGurmukhiUni AS definitionUni
+                FROM MahanKoshWords w
+                LEFT JOIN MahanKoshDefinitions d ON w.Definition = d.ID
+                WHERE
+                  w.Word LIKE ? OR
+                  w.WordUni LIKE BINARY ?
+                ORDER BY 
+                  CASE
+                    WHEN word LIKE ? THEN 1
+                    WHEN wordUni LIKE ? THEN 1
+                    WHEN word LIKE ? THEN 2
+                    WHEN wordUni LIKE ? THEN 2
+                    WHEN word LIKE ? THEN 3
+                    WHEN wordUni LIKE ? THEN 3
+                    ELSE 4
+                  END`;
+    console.log(q);
+    const rows = await conn.query(q, [
+      match,
+      match,
+      match,
+      match,
+      fullMatch,
+      fullMatch,
+      startMatch,
+      startMatch,
+      endMatch,
+      endMatch,
+    ]);
+    res.json(rows);
+  } catch (err) {
+    lib.error(err, res, 500);
+  } finally {
+    if (conn) conn.end();
+  }
+};
+
 exports.search = async (req, res) => {
   let conn;
-  const query = `%${req.params.query}%`;
+  const query = `${req.params.query}`;
+  const match = `%${query}%`;
+  const fullMatch = `${query}`;
+  const startMatch = `${query}%`;
+  const endMatch = `%${query}`;
   try {
     conn = await req.app.locals.pool.getConnection();
     const q = `SELECT w.ID AS id, w.Word AS word, w.WordUni AS wordUni,
@@ -59,8 +110,41 @@ exports.search = async (req, res) => {
                   w.WordUni LIKE BINARY ? OR
                   d.DefGurmukhi LIKE ? OR
                   d.DefGurmukhiUni LIKE BINARY ?
-                ORDER BY w.ID`;
-    const rows = await conn.query(q, [query, query, query, query]);
+                ORDER BY 
+                  CASE
+                    WHEN word LIKE ? THEN 1
+                    WHEN wordUni LIKE ? THEN 1
+                    WHEN word LIKE ? THEN 2
+                    WHEN wordUni LIKE ? THEN 2
+                    WHEN word LIKE ? THEN 3
+                    WHEN wordUni LIKE ? THEN 3
+                    WHEN definition LIKE ? THEN 4
+                    WHEN definitionUni LIKE ? THEN 4
+                    WHEN definition LIKE ? THEN 5
+                    WHEN definitionUni LIKE ? THEN 5
+                    WHEN definition LIKE ? THEN 6
+                    WHEN definitionUni LIKE ? THEN 6
+                    ELSE 7
+                  END`;
+    console.log(q);
+    const rows = await conn.query(q, [
+      match,
+      match,
+      match,
+      match,
+      fullMatch,
+      fullMatch,
+      startMatch,
+      startMatch,
+      endMatch,
+      endMatch,
+      fullMatch,
+      fullMatch,
+      startMatch,
+      startMatch,
+      endMatch,
+      endMatch,
+    ]);
     res.json(rows);
   } catch (err) {
     lib.error(err, res, 500);

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -58,6 +58,8 @@ route.get('/kosh/:Letter', limiter.rate100, kosh.letter);
 
 route.get('/kosh/word/:Word', limiter.rate100, kosh.word);
 
+route.get('/kosh/word/search/:query', limiter.rate100, kosh.wordSearch);
+
 route.get('/kosh/search/:query', limiter.rate100, kosh.search);
 
 // Rehat Routes

--- a/swagger.json
+++ b/swagger.json
@@ -346,6 +346,26 @@
         }
       }
     },
+    "/kosh/word/search/{query}": {
+      "get": {
+        "summary": "Kosh Search by word",
+        "description": "Get words in kosh table by query on words only.",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "description": "query to search on",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/kosh/search/{query}": {
       "get": {
         "summary": "Kosh Search",


### PR DESCRIPTION
Followed this example: https://www.codexworld.com/how-to/sort-results-order-by-best-match-using-like-in-mysql/

The order would be
1 -  if the query matches the words
2 - if the query matches the beginning of the word
3 - if the query matches the end of the word
4 -  if the query matches the definition
5 - if the query matches the beginning of the definition
6 - if the query matches the end of the definition

Also adds a new end point that searches only on words and not definitions.