### PR TITLE
Fix writer filter not applying for search type 3

### DIFF
--- a/api/lib/searchOperators.js
+++ b/api/lib/searchOperators.js
@@ -292,7 +292,7 @@ module.exports = {
     }
     return {
       columns: ' LEFT JOIN tokenized_english t ON t.verseid = v.ID',
-      condition: 't.token LIKE ? OR t.token LIKE ?',
+      condition: '(t.token LIKE ? OR t.token LIKE ?)',
       parameters: [`${lodash.upperFirst(searchQuery)}%`, `${lodash.lowerFirst(searchQuery)}%`],
     };
   },


### PR DESCRIPTION
Where clause wasn't grouped correctly. 

`v2/search/justice?source=all&searchtype=3&writer=12&page=1 ` will give 2 results instead of 127
