### PR TITLE
Add an endpoint to show specific verses

### DIFF
--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -31,6 +31,8 @@ route.get('/health', limiter.rate250, healthcheck.db);
 // Shabad Routes
 route.get('/search/:query', limiter.rate250, shabads.search);
 
+route.get('/search-results/:VerseID', limiter.rate250, shabads.resultsInfo);
+
 route.get('/shabads/:ShabadID', limiter.rate100, shabads.shabads);
 
 route.get('/angs/:PageNo/:SourceID?', limiter.rate100, shabads.angs);


### PR DESCRIPTION
In order to implement the semantic search API, we needed an endpoint that returns all the banidb details of specific verses. 

This PR adds endpoint **/search-results** which take comma separated verse ids as parameter, VerseID and returns all the information required to show those verses as search results.

Data at endpoint `/v2/search-results/212,1231`
![Screenshot from 2023-06-05 22-39-44](https://github.com/KhalisFoundation/banidb-api/assets/1990932/accecee2-616c-4c01-a2d7-4978b7d1cac5)

Sidenote: Also, pulled the commits from master branch here, so that dev is upto date with master branch commits.