### PR TITLE
Fix the timeout error in search-results endpoint.

### DIFF
--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -31,7 +31,7 @@ route.get('/health', limiter.rate250, healthcheck.db);
 // Shabad Routes
 route.get('/search/:query', limiter.rate250, shabads.search);
 
-route.get('/search-results/:VerseID', limiter.rate250, shabads.resultsInfo);
+route.get('/search-results/:VerseIds', limiter.rate250, shabads.resultsInfo);
 
 route.get('/shabads/:ShabadID', limiter.rate100, shabads.shabads);
 


### PR DESCRIPTION
Change the route variable name to VerseIds.
